### PR TITLE
[최지예] 25.04.04 17:16 Fix: reset selected company on page refresh in /select-company

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,10 +1,16 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <!-- 새로고침 감지용 스크립트 추가 -->
+    <script>
+      if (performance.navigation.type === 1) {
+        localStorage.setItem("wasRefreshed", "true");
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/pages/SelectCompany/MyCompanyComparison.jsx
+++ b/client/src/pages/SelectCompany/MyCompanyComparison.jsx
@@ -15,35 +15,45 @@ function MyCompanyComparison() {
 
   const [modalOpen, setModalOpen] = useState(false);
   const [mediaSize, setMediaSize] = useState("");
-  const [selectedCompany, setSelectedCompany] = useState(null); // '다른기업비교하기' 버튼에 의해 초기 상태가 이미 선택된 상태인 경우도 있음
+  const [selectedCompany, setSelectedCompany] = useState(null); // '다른 기업 비교하기' 버튼에 의해 초기 상태가 이미 선택된 상태인 경우도 있음
   const [compareCompanies, setCompareCompanies] = useState([]);
   const [recentMyCompanies, setRecentMyCompanies] = useState([]);
   const [selectionMode, setSelectionMode] = useState("my");
 
   useEffect(() => {
     const navigationEntry = performance.getEntriesByType("navigation")[0];
-    const isReload = navigationEntry?.type === "reload"; // 이부분이 사용자가 새로고침을 했을경우의 변수
+    const isReload = navigationEntry?.type === "reload"; // 사용자가 새로고침을 했을경우의 변수
     const state = location.state; // 이전 데이터 유지된 상태 유지 변수
+
+    const wasRefreshed = localStorage.getItem("wasRefreshed");
+
+    if (isReload && state?.preserveOnRefresh && wasRefreshed === "true") {
+      // 새로고침 시 로컬스토리지로 판단해 강제 초기화
+      localStorage.removeItem("wasRefreshed");
+      setSelectedCompany(null);
+      setCompareCompanies([]);
+      return;
+    }
 
     // state가 null이 아니라는 것이 확정된 이후에 처리
     if (state) {
       if (state.preserveOnRefresh) {
         // true일 경우 이전 데이터 상태복원
         setSelectedCompany(state.selectedCompany); // 선택된 기업 유지 상태로 저장
-        setCompareCompanies([]); // 비교 기업은 초기화화
+        setCompareCompanies([]); // 비교 기업은 초기화
       } else {
         setSelectedCompany(null); // '다른 기업 비교하기' 버튼을 누른게 아니라면 강제 초기화'
         setCompareCompanies([]);
       }
-    } else if (isReload || state === null) {
-      // 새로고침침하거나 선택한 기업 데이터가 아예 없다면
+    } else {
+      // 새로고침하거나 선택한 기업 데이터가 아예 없다면
       setSelectedCompany(null); // 전부 초기화
       setCompareCompanies([]);
     }
   }, [location.state]);
 
   useEffect(() => {
-    console.log("mediaSize 상태 변경됨 👉", mediaSize);
+    console.log("mediaSize 상태 변경됨: ", mediaSize);
   }, [mediaSize]);
 
   // '나의 기업' 선택 핸들러
@@ -107,7 +117,7 @@ function MyCompanyComparison() {
     });
   };
 
-  //반응형 디자인
+  // 반응형 디자인
   useEffect(() => {
     function updateMediaSize() {
       const { innerWidth: width } = window;


### PR DESCRIPTION
"다른 기업 비교하기" 버튼 누르면, /select-company 로 이동하면서 selectedCompany 유지됨.
이 상태에서 다른 기업을 선택할 수 있어야 하고
새로고침(F5) 시에는 selectedCompany가 유지되지 않아야 함.
즉, 선택된 기업도 초기화되고 완전한 초기 상태로 보이도록 구현함.